### PR TITLE
feat: add regctl OCI registry client

### DIFF
--- a/latest/Dockerfile.amd64
+++ b/latest/Dockerfile.amd64
@@ -1,3 +1,5 @@
+FROM regclient/regctl:v0.4.6 as regctl
+
 FROM alpine:3.17@sha256:69665d02cb32192e52e07644d76bc6f25abeb5410edc1c7a81a10ba3f0efb90a
 
 LABEL maintainer="ownCloud GmbH <devops@owncloud.com>"
@@ -47,4 +49,6 @@ RUN apk --update add --no-cache \
     rm -rf /var/cache/apk/* /tmp/*
 
 COPY ./rootfs /
+COPY --from=regctl /regctl /usr/local/bin/regctl
+
 CMD ["bash"]

--- a/latest/Dockerfile.arm32v7
+++ b/latest/Dockerfile.arm32v7
@@ -1,3 +1,5 @@
+FROM regclient/regctl:v0.4.6 as regctl
+
 FROM arm32v7/alpine:3.17@sha256:68a5b7d32422e42b98bedfe2aef4d0b3445f69f0efe390ba2204427d80179a92
 
 LABEL maintainer="ownCloud GmbH <devops@owncloud.com>"
@@ -47,4 +49,6 @@ RUN apk --update add --no-cache \
     rm -rf /var/cache/apk/* /tmp/*
 
 COPY ./rootfs /
+COPY --from=regctl /regctl /usr/local/bin/regctl
+
 CMD ["bash"]

--- a/latest/Dockerfile.arm64v8
+++ b/latest/Dockerfile.arm64v8
@@ -1,3 +1,5 @@
+FROM regclient/regctl:v0.4.6 as regctl
+
 FROM arm64v8/alpine:3.17@sha256:c41ab5c992deb4fe7e5da09f67a8804a46bd0592bfdf0b1847dde0e0889d2bff
 
 LABEL maintainer="ownCloud GmbH <devops@owncloud.com>"
@@ -47,4 +49,6 @@ RUN apk --update add --no-cache \
     rm -rf /var/cache/apk/* /tmp/*
 
 COPY ./rootfs /
+COPY --from=regctl /regctl /usr/local/bin/regctl
+
 CMD ["bash"]


### PR DESCRIPTION
As the current registry client [reg](https://github.com/genuinetools/reg) is unmaintained, I'm going to replace it by [regctl](https://github.com/regclient/regclient).